### PR TITLE
fix(docs): Add link to Survey in top bar

### DIFF
--- a/runatlantis.io/.vitepress/navbars.ts
+++ b/runatlantis.io/.vitepress/navbars.ts
@@ -4,6 +4,7 @@ const en = [
   { text: "Docs", link: "/docs" },
   { text: "Contributing", link: "/contributing" },
   { text: "Blog", link: "/blog" },
+  { text: "Survey", link: "https://docs.google.com/forms/d/1fOGWkdinDV2_46CZvzQRdz8401ypZR8Z-iwkNNt3EX0" },
 ];
 
 export { en };


### PR DESCRIPTION
In case folks dismiss the survey top bar, its still easily accessible
